### PR TITLE
add support for namespaced topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "convert_case",
+ "regex",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ required-features = ["json_schema"]
 [dependencies]
 clap = { version = "3.2.12", features = ["derive"] }
 convert_case = "0.5.0"
+regex = "1.6.0"
 schemars = { version = "0.8.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ You can also generate the schema from source with
 cargo run -F json_schema --bin generate-schema
 ```
 
+#### Namespaced Topics
+
+Sometimes a system may use namespaced topics to separate the channels between similar nodes. For example, a camera array may publish their images to `/camera_0/image_raw`, `/camera_1/image_raw`... etc. This can be represented with redf via variable subsitution.
+
+```yaml
+  - title: Camera Images
+    type: topic
+    description: Raw camera images
+    topic: '/{camera_id}/image_raw'
+    message_type: sensor_msgs/msg/Image
+```
+
+When redf generates code for this endpoint, it will have an argument in the `topic_name` function, e.g.
+
+```cpp
+static inline std::string topic_name(const std::string& camera_id) {
+  const std::string topic = "/" + camera_id + "/image_raw";
+  return topic;
+}
+```
+
+This also works for service and action names.
+
 ### Code Completion (vscode)
 
 **TODO: These instructions are for when the repo is public, you need to download the schema and point to it locally for now.**

--- a/src/cpp/header.hpp.j2
+++ b/src/cpp/header.hpp.j2
@@ -21,8 +21,8 @@ class {{ep.title | pascal}} {
 public:
   using MessageType = {{ ep.message_type | replace(from="/", to="::") }};
 
-  static inline std::string topic_name() {
-    static const std::string topic = "{{ep.topic}}";
+  static inline std::string topic_name({% for part in varsub(str=ep.topic, vars_only=True) %}{% if part.var %}const std::string& {{part.var}}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}) {
+    const std::string topic = {% for part in varsub(str=ep.topic) %}{% if part.var %}{{part.var}}{% else %}"{{part.raw}}"{% endif %}{% if not loop.last %} + {% endif %}{% endfor %};
     return topic;
   }
 
@@ -83,8 +83,8 @@ class {{ep.title | pascal}} {
 public:
   using ServiceType = {{ ep.service_type | replace(from="/", to="::") }};
 
-  static inline std::string service_name() {
-    static const std::string name = "{{ep.service_name}}";
+  static inline std::string service_name({% for part in varsub(str=ep.service_name, vars_only=True) %}{% if part.var %}const std::string& {{part.var}}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}) {
+    const std::string name = {% for part in varsub(str=ep.service_name) %}{% if part.var %}{{part.var}}{% else %}"{{part.raw}}"{% endif %}{% if not loop.last %} + {% endif %}{% endfor %};
     return name;
   }
 };
@@ -96,8 +96,8 @@ class {{ep.title | pascal}} {
 public:
   using ActionType = {{ ep.action_type | replace(from="/", to="::") }};
 
-  static inline std::string action_name() {
-    static const std::string name = "{{ep.action_name}}";
+  static inline std::string action_name({% for part in varsub(str=ep.action_name, vars_only=True) %}{% if part.var %}const std::string& {{part.var}}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}) {
+    const std::string name = {% for part in varsub(str=ep.action_name) %}{% if part.var %}{{part.var}}{% else %}"{{part.raw}}"{% endif %}{% if not loop.last %} + {% endif %}{% endfor %};
     return name;
   }
 };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,8 @@
 use convert_case::{Case, Casing};
+use regex::Regex;
+use serde_json::Map;
 use std::collections::HashMap;
-use tera::{Filter, Result, Tera, Test, Value};
+use tera::{Filter, Function, Result, Tera, Test, Value};
 
 struct Snake;
 
@@ -54,10 +56,72 @@ impl Test for IsQosDefault {
     }
 }
 
+struct VarSub;
+
+/// Destructure a string with the format `{var}` into parts. Each part is a map which contains
+/// they key `var` if it corresponds to a subsituted variable, else it contains the key `raw`
+/// if that part is not subsituted.
+///
+/// tera args:
+///   str: the string to destructure
+///   vars_only: if true, only return the variable names, this will skip all `raw` items.
+impl Function for VarSub {
+    fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
+        let v = args
+            .get("str")
+            .ok_or("Missing parameter 'str'")?
+            .as_str()
+            .ok_or("Expected a string")?;
+        let vars_only = match args.get("vars_only") {
+            Some(v) => v.as_bool().ok_or("Expected vars_only to be a boolean")?,
+            None => false,
+        };
+        let re = Regex::new("\\{(\\w+)\\}").unwrap();
+
+        if vars_only {
+            let mut parts: Vec<Value> = Vec::new();
+            re.captures_iter(v).for_each(|m| {
+                parts.push(Value::Object(Map::from_iter([(
+                    "var".to_string(),
+                    Value::String(m.get(1).unwrap().as_str().to_string()),
+                )])));
+            });
+            return Ok(Value::Array(parts));
+        }
+
+        let mut parts: Vec<Value> = Vec::new();
+        let mut cur = 0;
+        re.captures_iter(v).for_each(|m| {
+            let raw = v[cur..m.get(0).unwrap().start()].to_string();
+            if raw.len() > 0 {
+                parts.push(Value::Object(Map::from_iter([(
+                    "raw".to_string(),
+                    Value::String(raw),
+                )])));
+            }
+            let var = m.get(1).unwrap().as_str().to_string();
+            parts.push(Value::Object(Map::from_iter([(
+                "var".to_string(),
+                Value::String(var),
+            )])));
+            cur = m.get(0).unwrap().end();
+        });
+        let last = v[cur..].to_string();
+        if last.len() > 0 {
+            parts.push(Value::Object(Map::from_iter([(
+                "raw".to_string(),
+                Value::String(last),
+            )])));
+        }
+        return Ok(Value::Array(parts));
+    }
+}
+
 pub fn register_helpers(tera: &mut Tera) -> () {
     tera.register_filter("snake", Snake);
     tera.register_filter("pascal", Pascal);
     tera.register_tester("qos_preset", IsQosPreset);
     tera.register_tester("qos_profile", IsQosProfile);
     tera.register_tester("qos_default", IsQosDefault);
+    tera.register_function("varsub", VarSub);
 }

--- a/tests/test_api.redf.yaml
+++ b/tests/test_api.redf.yaml
@@ -84,3 +84,8 @@ endpoints:
     description: test action
     action_name: test_action
     action_type: example_interfaces/action/Fibonacci
+  - title: Namespaced Topic
+    type: topic
+    description: namespaced topic
+    topic: '/{test_namespace}/namespaced_topic'
+    message_type: std_msgs/msg/String


### PR DESCRIPTION
Sometimes a system may use namespaced topics to separate the channels between similar nodes. For example, a camera array may publish their images to `/camera_0/image_raw`, `/camera_1/image_raw`... etc. This can be represented with redf via variable subsitution.

```yaml
  - title: Camera Images
    type: topic
    description: Raw camera images
    topic: '/{camera_id}/image_raw'
    message_type: sensor_msgs/msg/Image
```

When redf generates code for this endpoint, it will have an argument in the `topic_name` function, e.g.

```cpp
static inline std::string topic_name(const std::string& camera_id) {
  const std::string topic = "/" + camera_id + "/image_raw";
  return topic;
}
```

This also works for service and action names.