### PR TITLE
Also export rclcpp_action

### DIFF
--- a/src/cpp/CMakeLists.txt.j2
+++ b/src/cpp/CMakeLists.txt.j2
@@ -34,6 +34,9 @@ install(
 )
 ament_export_targets({{project_name}})
 ament_export_dependencies(
+  {% if have_actions -%}
+  rclcpp_action
+  {%- endif %}
   {%- for pkg in packages %}
   {{pkg}}
   {%- endfor %}


### PR DESCRIPTION
Downstream pkgs that link to the CPP header file generated by redf may not require `rclcpp_action` and hence will not make any `find_package(rclcpp_action REQUIRED)` calls in their `CMakeLists.txt`. We should thus export this as a dep to prevent transitive linking issues for downstream pkgs.