### PR TITLE
Get ros distro at runtime

### DIFF
--- a/src/cpp/mod.rs
+++ b/src/cpp/mod.rs
@@ -4,6 +4,7 @@ use crate::utils::get_ros_types;
 use convert_case::{Case, Casing};
 use serde::Serialize;
 use std::collections::BTreeSet;
+use std::env;
 use std::error::Error;
 use std::path::Path;
 use tera::Tera;
@@ -50,9 +51,14 @@ pub fn generate(redf: &Redf, outdir: &Path) -> Result<(), Box<dyn Error>> {
         _ => false,
     });
 
+    let distro = match env::var("ROS_DISTRO") {
+        Ok(val) => val,
+        Err(_) => panic!("Fail to detect ROS version, make sure ROS is sourced"),
+    };
+
     let ctx = tera::Context::from_serialize(Context {
         redf,
-        distro: env!("ROS_DISTRO").to_string(),
+        distro,
         project_name: project_name.clone(),
         packages,
         ros_types,


### PR DESCRIPTION
This allows us to use the same release for different ROS versions. After this is merged, we can make a new release so nexus can fetch the correct version.