### PR TITLE
Link against _TARGETS

### DIFF
--- a/src/cpp/CMakeLists.txt.j2
+++ b/src/cpp/CMakeLists.txt.j2
@@ -20,7 +20,7 @@ target_include_directories({{project_name}} INTERFACE
 )
 target_link_libraries({{project_name}} INTERFACE rclcpp::rclcpp {% if have_actions -%} rclcpp_action::rclcpp_action {%- endif %}
 {%- for pkg in packages %}
-  {%raw%}${{%endraw%}{{pkg}}_LIBRARIES}
+  {%raw%}${{%endraw%}{{pkg}}_TARGETS}
 {%- endfor %}
 )
 set_target_properties({{project_name}} PROPERTIES PUBLIC_HEADER {{project_name}}.hpp)


### PR DESCRIPTION
It turns out passing libraries to link in `target_link_libraries()` as `${foo_pkg_LIBRARIES}` introduces a lot of duplicate of the same library that needs to be linked. This the reason why the `ld` linker takes a REALLY long time to finish linking since it does not de-duplicate the duplicate libraries and links all them. The `lld` linker seems to be smarter about this.

Switching to `${foo_pkg_TARGETS}` prevents the duplicate libraries that were previously included as transitives. This is also the pattern that ROS 2 follows. [See](https://github.com/ros2/geometry2/blob/9e9bfc59a8bd031f3d8b7cda5b7aa5a15bca034d/tf2_ros/CMakeLists.txt#L38-L39).
