### PR TITLE
Add jazzy to supported distros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_image: ['ros:humble-ros-base', 'ros:iron-ros-base']
+        docker_image: ['ros:humble-ros-base', 'ros:iron-ros-base', 'ros:jazzy-ros-base']
     container:
       image: ${{ matrix.docker_image }}
     steps:

--- a/src/cpp/mod.rs
+++ b/src/cpp/mod.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 use std::path::Path;
 use tera::Tera;
 
-const SUPPORTED_DISTRO: &[&str] = &["humble", "iron"];
+const SUPPORTED_DISTRO: &[&str] = &["humble", "iron", "jazzy"];
 
 #[derive(Serialize)]
 struct Context<'a> {


### PR DESCRIPTION
I was trying to run this in Jazzy and it failed, I haven't checked that it actually does what it's supposed to but from my understanding there wasn't any major (or any at all?) in services / actions / pub sub in Jazzy so it should be a smooth transition